### PR TITLE
feat: Add repo iteration and simple job for updating LICENSE year

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,4 +19,7 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm run build
-      - run: npm start
+      # TODO enable this once it's safe
+      #- run: npm start
+      #  env:
+      #    GRAA_TOKEN: ${{ secrets.GRAA_TOKEN }}

--- a/automations/license-date.ts
+++ b/automations/license-date.ts
@@ -1,0 +1,89 @@
+import { tryReadFileAsUtf8 } from '../lib/content.js'
+import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
+import { createPrToUpdateFile } from '../lib/pr.js'
+
+const LICENSE_PATH = 'LICENSE'
+
+interface LicenseYearRange {
+  start: number
+  end: number
+}
+
+/**
+ * Run a job for updating the year range in the 'LICENSE' file to include the year of the most recent commit.
+ *
+ * @param octokit The API instance.
+ * @param repo The repo to run this action on.
+ */
+export async function licenseDate (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser): Promise<void> {
+  const license = await tryReadFileAsUtf8(octokit, {
+    owner: repo.owner.login,
+    repo: repo.name,
+    path: LICENSE_PATH
+  })
+  if (license == null) {
+    return
+  }
+
+  const licenseYears = extractRange(license.content)
+  if (licenseYears == null) {
+    return
+  }
+
+  const mainBranch = await octokit.rest.repos.getBranch({
+    owner: repo.owner.login,
+    repo: repo.name,
+    branch: repo.default_branch
+  })
+
+  const lastCommit = mainBranch.data.commit
+  const lastCommitDate = lastCommit?.commit?.committer?.date
+  if (lastCommitDate == null) {
+    return
+  }
+
+  const commitYear = parseInt(lastCommitDate.slice(0, 4), 10)
+
+  if (licenseYears.end < commitYear) {
+    const newRange: LicenseYearRange = {
+      ...licenseYears,
+      end: commitYear
+    }
+
+    await createPrToUpdateFile(octokit, repo, {
+      fileBlobSha: license.sha,
+      path: LICENSE_PATH,
+      content: updateRange(license.content, newRange)
+    }, {
+      branch: 'chore/license-copyright-year',
+      parentCommitSha: lastCommit.sha,
+      subject: 'chore(license): Update copyright range',
+      comment: `Note: This PR was created automatically by [GRAA](https://github.com/meyfa/graa).\n\nIt looks like the most recent commit is dated to the year ${commitYear}. This PR updates the copyright range in LICENSE to match that.`
+    })
+  }
+}
+
+function extractRange (licenseText: string): LicenseYearRange | undefined {
+  if (!licenseText.startsWith('MIT License')) {
+    // can only handle MIT for now
+    return undefined
+  }
+
+  // uncaptured prefix + range start + optional range end + uncaptured suffix
+  const match = licenseText.match(/^Copyright \(c\) (\d{4})(?: - (\d{4}))? .+$/m)
+  if (match == null) {
+    return undefined
+  }
+
+  const start = parseInt(match[1], 10)
+  const end = match[2]?.length > 0 ? parseInt(match[2], 10) : start
+
+  return { start, end }
+}
+
+function updateRange (licenseText: string, newRange: LicenseYearRange): string {
+  const rangeString = newRange.end === newRange.start ? `${newRange.start}` : `${newRange.start} - ${newRange.end}`
+
+  // prefix + current range spec + suffix
+  return licenseText.replace(/^(Copyright \(c\) )(\d{4}(?: - \d{4})?)( .+)$/m, '$1' + rangeString + '$3')
+}

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,52 @@
-console.log('hello world')
+import { Octokit } from '@octokit/core'
+import { paginateRest } from '@octokit/plugin-paginate-rest'
+import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods'
+import { GraaOctokit, RepoOfAuthenticatedUser } from './lib/types.js'
+import { licenseDate } from './automations/license-date.js'
+
+class ConfigError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = ConfigError.name
+  }
+}
+
+function ensureToken (): string {
+  const token = process.env.GRAA_TOKEN
+  if (typeof token !== 'string' || token.length <= 0) {
+    throw new ConfigError('Cannot run, the GRAA_TOKEN env variable is not set!')
+  }
+
+  return token
+}
+
+const GRAA_TOKEN = ensureToken()
+
+const MyOctokit = Octokit.plugin(paginateRest).plugin(restEndpointMethods)
+const octokit: GraaOctokit = new MyOctokit({
+  auth: GRAA_TOKEN
+})
+
+async function handleAllRepos (): Promise<void> {
+  const repoFilter = {
+    affiliation: 'owner',
+    visibility: 'public',
+    per_page: 100
+  } as const
+
+  for await (const repos of octokit.paginate.iterator(octokit.rest.repos.listForAuthenticatedUser, repoFilter)) {
+    for (const repo of repos.data) {
+      await handleRepo(repo)
+    }
+  }
+}
+
+async function handleRepo (repo: RepoOfAuthenticatedUser): Promise<void> {
+  if (repo.private || repo.archived || repo.disabled || repo.fork || repo.owner.type !== 'User') {
+    return
+  }
+
+  await licenseDate(octokit, repo)
+}
+
+await handleAllRepos()

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,23 @@
+import { GraaOctokit } from './types.js'
+
+export interface ReadFile {
+  sha: string
+  content: string
+}
+
+export async function tryReadFileAsUtf8 (octokit: GraaOctokit, params: { owner: string, repo: string, path: string }): Promise<ReadFile | undefined> {
+  const response = await octokit.rest.repos.getContent({
+    owner: params.owner,
+    repo: params.repo,
+    path: params.path
+  })
+
+  if (!('encoding' in response.data) || response.data.encoding !== 'base64') {
+    return undefined
+  }
+
+  return {
+    sha: response.data.sha,
+    content: Buffer.from(response.data.content, 'base64').toString('utf8')
+  }
+}

--- a/lib/pr.ts
+++ b/lib/pr.ts
@@ -1,0 +1,42 @@
+import { GraaOctokit, RepoOfAuthenticatedUser } from './types.js'
+
+export interface FileChange {
+  fileBlobSha: string
+  path: string
+  content: string
+}
+
+export interface PullRequestMetadata {
+  branch: string
+  parentCommitSha: string
+  subject: string
+  comment: string
+}
+
+export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, change: FileChange, meta: PullRequestMetadata): Promise<void> {
+  await octokit.rest.git.createRef({
+    owner: repo.owner.login,
+    repo: repo.name,
+    ref: `refs/heads/${meta.branch}`,
+    sha: meta.parentCommitSha
+  })
+
+  await octokit.rest.repos.createOrUpdateFileContents({
+    owner: repo.owner.login,
+    repo: repo.name,
+    branch: meta.branch,
+    path: change.path,
+    sha: change.fileBlobSha,
+    content: Buffer.from(change.content, 'utf8').toString('base64'),
+    message: meta.subject
+  })
+
+  await octokit.rest.pulls.create({
+    owner: repo.owner.login,
+    repo: repo.name,
+    title: meta.subject,
+    body: meta.comment,
+    head: meta.branch,
+    base: repo.default_branch
+  })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,13 @@
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types'
+import { Octokit } from '@octokit/core'
+import { Constructor } from '@octokit/core/dist-types/types.js'
+import { Api } from '@octokit/plugin-rest-endpoint-methods/dist-types/types.js'
+import { PaginateInterface } from '@octokit/plugin-paginate-rest'
+
+export type GraaOctokit = InstanceType<typeof Octokit & Constructor<Api> & Constructor<{ paginate: PaginateInterface }>>
+
+// this is the type of the octokit.rest object
+type RestMethods = GraaOctokit['rest']
+
+export type RepoOfAuthenticatedUser = GetResponseDataTypeFromEndpointMethod<RestMethods['repos']['listForAuthenticatedUser']>[number]
+export type BranchOfRepo = GetResponseDataTypeFromEndpointMethod<RestMethods['repos']['getBranch']>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,117 @@
       "name": "graa",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "3.6.0",
+        "@octokit/plugin-paginate-rest": "2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "5.13.0",
+        "@octokit/types": "6.34.0"
+      },
       "devDependencies": {
         "@types/node": "17.0.25",
         "rimraf": "3.0.2",
         "typescript": "4.6.3"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^11.2.0"
       }
     },
     "node_modules/@types/node": {
@@ -25,6 +132,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -41,6 +153,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -84,6 +201,14 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -96,11 +221,29 @@
         "node": "*"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -129,6 +272,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
@@ -142,14 +290,127 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   },
   "dependencies": {
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "requires": {
+        "@octokit/types": "^6.34.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "requires": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "requires": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
     "@types/node": {
       "version": "17.0.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
@@ -161,6 +422,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -177,6 +443,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -214,6 +485,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -223,11 +499,18 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -247,17 +530,40 @@
         "glob": "^7.1.3"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
     "@types/node": "17.0.25",
     "rimraf": "3.0.2",
     "typescript": "4.6.3"
+  },
+  "dependencies": {
+    "@octokit/core": "3.6.0",
+    "@octokit/plugin-paginate-rest": "2.17.0",
+    "@octokit/plugin-rest-endpoint-methods": "5.13.0",
+    "@octokit/types": "6.34.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
+    "moduleResolution": "Node",
     "strict": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
This adds code to index.ts that iterates over all of the user's repos,
and for each, executes a set of automations. One such automation is
implemented (although only very crudely). Its job is to look at the
last commit date, and see if it is newer than the year range specified
in the LICENSE file, and if so, create a pull request to update the
year range in LICENSE. There is absolutely no error handling or
checking for already existing branches or PRs yet. Hence, the CI step
to execute the script is disabled for safety.