### PR TITLE
feat: Implement repo config files (.graa.yml) and scoped logging

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,18 +3,20 @@ import { paginateRest } from '@octokit/plugin-paginate-rest'
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods'
 import { GraaOctokit, RepoOfAuthenticatedUser } from './lib/types.js'
 import { licenseDate } from './automations/license-date.js'
+import { getConfig } from './lib/config.js'
+import { globalLog, Log, withRepoScope, withAutomationScope } from './lib/log.js'
+import { AuthError, RepoConfigError } from './lib/errors.js'
 
-class ConfigError extends Error {
-  constructor (message: string) {
-    super(message)
-    this.name = ConfigError.name
-  }
-}
+type Automation = (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser) => Promise<void>
+
+const AUTOMATIONS: ReadonlyMap<string, Automation> = new Map([
+  ['license-date', licenseDate]
+])
 
 function ensureToken (): string {
   const token = process.env.GRAA_TOKEN
   if (typeof token !== 'string' || token.length <= 0) {
-    throw new ConfigError('Cannot run, the GRAA_TOKEN env variable is not set!')
+    throw new AuthError('Cannot run, the GRAA_TOKEN env variable is not set!')
   }
 
   return token
@@ -27,7 +29,7 @@ const octokit: GraaOctokit = new MyOctokit({
   auth: GRAA_TOKEN
 })
 
-async function handleAllRepos (): Promise<void> {
+async function handleAllRepos (log: Log): Promise<void> {
   const repoFilter = {
     affiliation: 'owner',
     visibility: 'public',
@@ -36,17 +38,48 @@ async function handleAllRepos (): Promise<void> {
 
   for await (const repos of octokit.paginate.iterator(octokit.rest.repos.listForAuthenticatedUser, repoFilter)) {
     for (const repo of repos.data) {
-      await handleRepo(repo)
+      const scopedLog = withRepoScope(log, repo)
+      try {
+        await handleRepo(scopedLog, repo)
+      } catch (err: unknown) {
+        scopedLog.error(err)
+      }
     }
   }
 }
 
-async function handleRepo (repo: RepoOfAuthenticatedUser): Promise<void> {
+async function handleRepo (log: Log, repo: RepoOfAuthenticatedUser): Promise<void> {
   if (repo.private || repo.archived || repo.disabled || repo.fork || repo.owner.type !== 'User') {
     return
   }
 
-  await licenseDate(octokit, repo)
+  const config = await getConfig(octokit, repo)
+  if (config == null) {
+    log.info('Skipping (not configured)')
+    return
+  }
+
+  log.info('Running')
+  for (const automationId of config.automations) {
+    await runAutomation(log, repo, automationId)
+  }
 }
 
-await handleAllRepos()
+async function runAutomation (log: Log, repo: RepoOfAuthenticatedUser, automationId: string): Promise<void> {
+  const automation = AUTOMATIONS.get(automationId)
+  if (automation == null) {
+    throw new RepoConfigError(repo, `Unknown automation '${automationId}'!`)
+  }
+
+  const scopedLog = withAutomationScope(log, automationId)
+  scopedLog.info('Running')
+
+  await automation(log, octokit, repo)
+}
+
+try {
+  await handleAllRepos(globalLog)
+} catch (err: unknown) {
+  globalLog.error(err)
+  process.exit(1)
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,60 @@
+import { GraaOctokit, RepoOfAuthenticatedUser } from './types.js'
+import { tryReadFileAsUtf8 } from './content.js'
+import { array, Infer, object, optional, string, validate } from 'superstruct'
+import * as YAML from 'yaml'
+
+const CONFIG_PATH = '.graa.yml'
+
+export interface Config {
+  readonly automations: readonly string[]
+}
+
+const EMPTY_CONFIG: Config = {
+  automations: []
+}
+
+const PartialConfigSchema = object({
+  automations: optional(array(string()))
+})
+
+export type PartialConfig = Infer<typeof PartialConfigSchema>
+
+async function readPartialConfig (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser): Promise<PartialConfig | undefined> {
+  const configFile = await tryReadFileAsUtf8(octokit, {
+    owner: repo.owner.login,
+    repo: repo.name,
+    path: CONFIG_PATH
+  })
+
+  if (configFile != null) {
+    const asYaml = YAML.parse(configFile.content)
+    const [error, config] = validate(asYaml, PartialConfigSchema, { coerce: true })
+    if (error != null || config == null) {
+      return undefined
+    }
+    return config
+  }
+
+  return undefined
+}
+
+function mergeConfig (base: Config, extend: PartialConfig): Config {
+  const automations = [...base.automations]
+  for (const automation of extend.automations ?? []) {
+    if (!automations.includes(automation)) {
+      automations.push(automation)
+    }
+  }
+
+  return { ...base, automations }
+}
+
+export async function getConfig (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser): Promise<Config | undefined> {
+  const partial = await readPartialConfig(octokit, repo)
+
+  if (partial != null) {
+    return mergeConfig(EMPTY_CONFIG, partial)
+  }
+
+  return undefined
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,16 +1,29 @@
 import { GraaOctokit } from './types.js'
 
+function isObjectWithStatus (thing: unknown): thing is { status: unknown } {
+  return typeof thing === 'object' && thing != null && 'status' in thing
+}
+
 export interface ReadFile {
   sha: string
   content: string
 }
 
 export async function tryReadFileAsUtf8 (octokit: GraaOctokit, params: { owner: string, repo: string, path: string }): Promise<ReadFile | undefined> {
-  const response = await octokit.rest.repos.getContent({
-    owner: params.owner,
-    repo: params.repo,
-    path: params.path
-  })
+  let response
+
+  try {
+    response = await octokit.rest.repos.getContent({
+      owner: params.owner,
+      repo: params.repo,
+      path: params.path
+    })
+  } catch (err: unknown) {
+    if (isObjectWithStatus(err) && err.status === 404) {
+      return undefined
+    }
+    throw err
+  }
 
   if (!('encoding' in response.data) || response.data.encoding !== 'base64') {
     return undefined

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,24 @@
+import { RepoOfAuthenticatedUser } from './types.js'
+
+export class AuthError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = AuthError.name
+  }
+}
+
+export abstract class RepoError extends Error {
+  readonly repo: string
+
+  protected constructor (repo: RepoOfAuthenticatedUser, message: string) {
+    super(message)
+    this.repo = repo.full_name
+  }
+}
+
+export class RepoConfigError extends RepoError {
+  constructor (repo: RepoOfAuthenticatedUser, message: string) {
+    super(repo, message)
+    this.name = RepoConfigError.name
+  }
+}

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,0 +1,26 @@
+import { RepoOfAuthenticatedUser } from './types.js'
+
+export interface Log {
+  info: (message: any, ...args: any[]) => void
+  error: (message: any, ...args: any[]) => void
+}
+
+export const globalLog: Log = {
+  info (message, ...args) {
+    console.log(message, ...args)
+  },
+
+  error (message, ...args) {
+    console.error(message, ...args)
+  }
+}
+
+function prefixedLog (base: Log, prefix: string): Log {
+  return {
+    info: (message, ...args) => base.info(prefix, message, ...args),
+    error: (message, ...args) => base.error(prefix, message, ...args)
+  }
+}
+
+export const withRepoScope = (log: Log, repo: RepoOfAuthenticatedUser): Log => prefixedLog(log, `${repo.full_name}:`)
+export const withAutomationScope = (log: Log, automationId: string): Log => prefixedLog(log, `${automationId}`)

--- a/lib/pr.ts
+++ b/lib/pr.ts
@@ -13,7 +13,11 @@ export interface PullRequestMetadata {
   comment: string
 }
 
-export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, change: FileChange, meta: PullRequestMetadata): Promise<void> {
+export interface PullRequestResult {
+  webUrl: string
+}
+
+export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, change: FileChange, meta: PullRequestMetadata): Promise<PullRequestResult> {
   await octokit.rest.git.createRef({
     owner: repo.owner.login,
     repo: repo.name,
@@ -31,7 +35,7 @@ export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAu
     message: meta.subject
   })
 
-  await octokit.rest.pulls.create({
+  const pr = await octokit.rest.pulls.create({
     owner: repo.owner.login,
     repo: repo.name,
     title: meta.subject,
@@ -39,4 +43,8 @@ export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAu
     head: meta.branch,
     base: repo.default_branch
   })
+
+  return {
+    webUrl: pr.data._links.html.href
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@octokit/core": "3.6.0",
         "@octokit/plugin-paginate-rest": "2.17.0",
         "@octokit/plugin-rest-endpoint-methods": "5.13.0",
-        "@octokit/types": "6.34.0"
+        "@octokit/types": "6.34.0",
+        "superstruct": "0.15.4",
+        "yaml": "2.0.1"
       },
       "devDependencies": {
         "@types/node": "17.0.25",
@@ -272,6 +274,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/superstruct": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.4.tgz",
+      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -313,6 +320,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/yaml": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.1.tgz",
+      "integrity": "sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg==",
+      "engines": {
+        "node": ">= 14"
+      }
     }
   },
   "dependencies": {
@@ -530,6 +545,11 @@
         "glob": "^7.1.3"
       }
     },
+    "superstruct": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.4.tgz",
+      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw=="
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -564,6 +584,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yaml": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.1.tgz",
+      "integrity": "sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@octokit/core": "3.6.0",
     "@octokit/plugin-paginate-rest": "2.17.0",
     "@octokit/plugin-rest-endpoint-methods": "5.13.0",
-    "@octokit/types": "6.34.0"
+    "@octokit/types": "6.34.0",
+    "superstruct": "0.15.4",
+    "yaml": "2.0.1"
   }
 }


### PR DESCRIPTION
This patch adds reading of config files, of which there should be one
per repo. The file must be called '.graa.yml'. If no such file is
present in a repo, the repo will be skipped (making GRAA essentially
opt-in). A config file can specify an array of automations that should
be performed for the repo.

Additionally, a logging system is implemented that prefixes messages
with the repo full_name and potentially the automation id, if the
message is logged from an automation. This is done by hierarchically
creating loggers and passing them between functions.