### PR TITLE
feat: Implement config 'extends' and add 'base' config

### DIFF
--- a/configs/base.ts
+++ b/configs/base.ts
@@ -1,0 +1,7 @@
+import { PartialConfig } from '../lib/config.js'
+
+export const baseConfig: PartialConfig = {
+  automations: [
+    'license-date'
+  ]
+}


### PR DESCRIPTION
By specifying a property 'extends: "config:base"' in the repo config,
all automations specified in configs/base.ts will automatically be
enabled.