### PR TITLE
feat: Change 'automations' property to support config objects

### DIFF
--- a/automations/license-date.ts
+++ b/automations/license-date.ts
@@ -2,9 +2,13 @@ import { tryReadFileAsUtf8 } from '../lib/content.js'
 import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
 import { createPrToUpdateFile, searchExistingPr } from '../lib/pr.js'
 import { Log } from '../lib/log.js'
+import { object } from 'superstruct'
+import { assertAutomationOptions } from '../lib/validation.js'
 
 const LICENSE_PATH = 'LICENSE'
 const BRANCH_NAME = 'chore/license-copyright-year'
+
+const Options = object({})
 
 interface LicenseYearRange {
   start: number
@@ -17,8 +21,11 @@ interface LicenseYearRange {
  * @param log The scoped logger.
  * @param octokit The API instance.
  * @param repo The repo to run this action on.
+ * @param options The automation options.
  */
-export async function licenseDate (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser): Promise<void> {
+export async function licenseDate (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
+  assertAutomationOptions(repo, Options, options)
+
   const license = await tryReadFileAsUtf8(octokit, {
     owner: repo.owner.login,
     repo: repo.name,

--- a/configs/base.ts
+++ b/configs/base.ts
@@ -1,7 +1,7 @@
 import { PartialConfig } from '../lib/config.js'
 
 export const baseConfig: PartialConfig = {
-  automations: [
-    'license-date'
-  ]
+  automations: {
+    'license-date': {}
+  }
 }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,11 @@
+import { Struct } from 'superstruct'
+import { RepoOfAuthenticatedUser } from './types.js'
+import { RepoConfigError } from './errors.js'
+
+export function assertAutomationOptions<T> (repo: RepoOfAuthenticatedUser, struct: Struct<T>, options: unknown): T {
+  const [err, validatedBody] = struct.validate(options, { coerce: true })
+  if (err != null || validatedBody == null) {
+    throw new RepoConfigError(repo, 'Invalid options object')
+  }
+  return validatedBody
+}


### PR DESCRIPTION
Instead of being an array, the 'automations' property is now a record.
The keys are the automation ids, and their values must be objects, in
which the respective options can be specified. Note that the only
currently existing automation 'license-date' has no options. This is
purely for future support.