### PR TITLE
feat: Add automation 'reconfigure' for changing repo settings

### DIFF
--- a/automations/reconfigure.ts
+++ b/automations/reconfigure.ts
@@ -1,0 +1,28 @@
+import { Log } from '../lib/log.js'
+import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
+import { boolean, defaulted, object } from 'superstruct'
+import { assertAutomationOptions } from '../lib/validation.js'
+
+const Options = object({
+  'delete-branch-on-merge': defaulted(boolean(), false)
+})
+
+/**
+ * Run a job for reconfiguring a subset of the repository settings.
+ *
+ * @param log The scoped logger.
+ * @param octokit The API instance.
+ * @param repo The repo to run this action on.
+ * @param options The automation options.
+ */
+export async function reconfigure (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
+  const opt = assertAutomationOptions(repo, Options, options)
+
+  octokit.rest.repos.update({
+    owner: repo.owner.login,
+    repo: repo.name,
+
+    // sample setting
+    delete_branch_on_merge: opt['delete-branch-on-merge']
+  })
+}

--- a/automations/reconfigure.ts
+++ b/automations/reconfigure.ts
@@ -18,7 +18,7 @@ const Options = object({
 export async function reconfigure (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
   const opt = assertAutomationOptions(repo, Options, options)
 
-  octokit.rest.repos.update({
+  await octokit.rest.repos.update({
     owner: repo.owner.login,
     repo: repo.name,
 

--- a/configs/base.ts
+++ b/configs/base.ts
@@ -2,6 +2,9 @@ import { PartialConfig } from '../lib/config.js'
 
 export const baseConfig: PartialConfig = {
   automations: {
+    reconfigure: {
+      'delete-branch-on-merge': true
+    },
     'license-date': {}
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -6,11 +6,13 @@ import { licenseDate } from './automations/license-date.js'
 import { getConfig } from './lib/config.js'
 import { globalLog, Log, withRepoScope, withAutomationScope } from './lib/log.js'
 import { AuthError, RepoConfigError } from './lib/errors.js'
+import { reconfigure } from './automations/reconfigure.js'
 
 type Automation = (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object) => Promise<void>
 
 const AUTOMATIONS: ReadonlyMap<string, Automation> = new Map([
-  ['license-date', licenseDate]
+  ['license-date', licenseDate],
+  ['reconfigure', reconfigure]
 ])
 
 function ensureToken (): string {


### PR DESCRIPTION
The automation can currently configure the 'delete-branch-on-merge'
setting. This option is set to true in 'config:base', since I assume
it is always wanted and will also improve the GRAA workflow by avoiding
branch name conflicts.