### PR TITLE
feat(files): Add automation for setting file contents

### DIFF
--- a/automations/files.ts
+++ b/automations/files.ts
@@ -1,0 +1,77 @@
+import { Log } from '../lib/log.js'
+import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
+import { record, string } from 'superstruct'
+import { assertAutomationOptions } from '../lib/validation.js'
+import { tryReadFileAsUtf8 } from '../lib/content.js'
+import { createPrToUpdateFile, searchExistingPr } from '../lib/pr.js'
+
+const Options = record(string(), string())
+
+function pathToBranchName (path: string): string {
+  const normalized = path.slice(-50)
+    .replace(/[^a-zA-Z\d]/g, '-')
+    .replace(/-+/, '-')
+    .replace(/^-|-$/g, '')
+
+  return `chore/update-${normalized}`
+}
+
+async function handleFile (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, path: string, expectedContent: string): Promise<void> {
+  const mainBranch = await octokit.rest.repos.getBranch({
+    owner: repo.owner.login,
+    repo: repo.name,
+    branch: repo.default_branch
+  })
+
+  const current = await tryReadFileAsUtf8(octokit, {
+    owner: repo.owner.login,
+    repo: repo.name,
+    path
+  })
+
+  if (current?.content === expectedContent) {
+    log.info(`${path}: Already up to date`)
+    return
+  }
+
+  if (current == null) {
+    log.info(`${path}: File does not exist, should create`)
+  } else {
+    log.info(`${path}: File contents differ from expected, should update`)
+  }
+
+  const branch = pathToBranchName(path)
+
+  const existing = await searchExistingPr(octokit, repo, branch)
+  if (existing != null) {
+    log.info(`A PR already exists for branch ${branch}, see ${existing.webUrl}`)
+    return
+  }
+
+  await createPrToUpdateFile(octokit, repo, {
+    path,
+    fileBlobSha: current?.sha,
+    content: expectedContent
+  }, {
+    branch,
+    parentCommitSha: mainBranch.data.commit.sha,
+    subject: `chore: Update ${path}`,
+    comment: 'The file content currently does not match the configured expected value, which is fixed through this PR.'
+  })
+}
+
+/**
+ * Run a job for setting the contents of one or more files to specific fixed values.
+ *
+ * @param log The scoped logger.
+ * @param octokit The API instance.
+ * @param repo The repo to run this action on.
+ * @param options The automation options.
+ */
+export async function files (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
+  const opt = assertAutomationOptions(repo, Options, options)
+
+  for (const [path, contents] of Object.entries(opt)) {
+    await handleFile(log, octokit, repo, path, contents)
+  }
+}

--- a/automations/license-date.ts
+++ b/automations/license-date.ts
@@ -82,7 +82,7 @@ export async function licenseDate (log: Log, octokit: GraaOctokit, repo: RepoOfA
     branch: BRANCH_NAME,
     parentCommitSha: lastCommit.sha,
     subject: 'chore(license): Update copyright range',
-    comment: `Note: This PR was created automatically by [GRAA](https://github.com/meyfa/graa).\n\nIt looks like the most recent commit is dated to the year ${commitYear}. This PR updates the copyright range in LICENSE to match that.`
+    comment: `It looks like the most recent commit is dated to the year ${commitYear}. This PR updates the copyright range in LICENSE to match that.`
   })
 
   log.info(`PR created, see ${pr.webUrl}`)

--- a/index.ts
+++ b/index.ts
@@ -7,12 +7,14 @@ import { getConfig } from './lib/config.js'
 import { globalLog, Log, withRepoScope, withAutomationScope } from './lib/log.js'
 import { AuthError, RepoConfigError } from './lib/errors.js'
 import { reconfigure } from './automations/reconfigure.js'
+import { files } from './automations/files.js'
 
 type Automation = (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object) => Promise<void>
 
 const AUTOMATIONS: ReadonlyMap<string, Automation> = new Map([
   ['license-date', licenseDate],
-  ['reconfigure', reconfigure]
+  ['reconfigure', reconfigure],
+  ['files', files]
 ])
 
 function ensureToken (): string {

--- a/lib/pr.ts
+++ b/lib/pr.ts
@@ -1,7 +1,7 @@
 import { GraaOctokit, RepoOfAuthenticatedUser } from './types.js'
 
 export interface FileChange {
-  fileBlobSha: string
+  fileBlobSha?: string
   path: string
   content: string
 }
@@ -57,7 +57,7 @@ export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAu
     owner: repo.owner.login,
     repo: repo.name,
     title: meta.subject,
-    body: meta.comment,
+    body: `Note: This PR was created automatically by [GRAA](https://github.com/meyfa/graa).\n\n${meta.comment}`,
     head: meta.branch,
     base: repo.default_branch
   })


### PR DESCRIPTION
The new 'files' automation will iterate over its option keys, each of
which represents a file path and the respective value represents the
expected file content at that path. If there is a mismatch, a PR will be
created to update the file contents to match the expected value.