### PR TITLE
feat: Implement merging of automation options for extended configs

### DIFF
--- a/automations/files.ts
+++ b/automations/files.ts
@@ -1,7 +1,7 @@
+import { Automation } from '../lib/automation.js'
 import { Log } from '../lib/log.js'
 import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
-import { record, string } from 'superstruct'
-import { assertAutomationOptions } from '../lib/validation.js'
+import { Infer, record, string } from 'superstruct'
 import { tryReadFileAsUtf8 } from '../lib/content.js'
 import { createPrToUpdateFile, searchExistingPr } from '../lib/pr.js'
 
@@ -63,17 +63,18 @@ async function handleFile (log: Log, octokit: GraaOctokit, repo: RepoOfAuthentic
 }
 
 /**
- * Run a job for setting the contents of one or more files to specific fixed values.
- *
- * @param log The scoped logger.
- * @param octokit The API instance.
- * @param repo The repo to run this action on.
- * @param options The automation options.
+ * An automation for setting the contents of one or more files to specific fixed values.
  */
-export async function files (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
-  const opt = assertAutomationOptions(repo, Options, options)
+export const files: Automation<Infer<typeof Options>> = {
+  optionsStruct: Options,
 
-  for (const [path, contents] of Object.entries(opt)) {
-    await handleFile(log, octokit, repo, path, contents)
+  combineOptions (base, extend) {
+    return { ...base, ...extend }
+  },
+
+  async run (log, octokit, repo, options) {
+    for (const [path, contents] of Object.entries(options)) {
+      await handleFile(log, octokit, repo, path, contents)
+    }
   }
 }

--- a/automations/license-date.ts
+++ b/automations/license-date.ts
@@ -1,9 +1,7 @@
+import { Automation } from '../lib/automation.js'
 import { tryReadFileAsUtf8 } from '../lib/content.js'
-import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
 import { createPrToUpdateFile, searchExistingPr } from '../lib/pr.js'
-import { Log } from '../lib/log.js'
-import { object } from 'superstruct'
-import { assertAutomationOptions } from '../lib/validation.js'
+import { Infer, object } from 'superstruct'
 
 const LICENSE_PATH = 'LICENSE'
 const BRANCH_NAME = 'chore/license-copyright-year'
@@ -16,76 +14,77 @@ interface LicenseYearRange {
 }
 
 /**
- * Run a job for updating the year range in the 'LICENSE' file to include the year of the most recent commit.
- *
- * @param log The scoped logger.
- * @param octokit The API instance.
- * @param repo The repo to run this action on.
- * @param options The automation options.
+ * An automation for updating the year range in the 'LICENSE' file to include the year of the most recent commit.
  */
-export async function licenseDate (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
-  assertAutomationOptions(repo, Options, options)
+export const licenseDate: Automation<Infer<typeof Options>> = {
+  optionsStruct: Options,
 
-  const license = await tryReadFileAsUtf8(octokit, {
-    owner: repo.owner.login,
-    repo: repo.name,
-    path: LICENSE_PATH
-  })
-  if (license == null) {
-    log.info('Skipping (no license file found)')
-    return
+  combineOptions (base, extend) {
+    return { ...base, ...extend }
+  },
+
+  async run (log, octokit, repo, options) {
+    const license = await tryReadFileAsUtf8(octokit, {
+      owner: repo.owner.login,
+      repo: repo.name,
+      path: LICENSE_PATH
+    })
+    if (license == null) {
+      log.info('Skipping (no license file found)')
+      return
+    }
+
+    const licenseYears = extractRange(license.content)
+    if (licenseYears == null) {
+      log.info('Skipping (unable to extract a date range from the license file)')
+      return
+    }
+
+    const mainBranch = await octokit.rest.repos.getBranch({
+      owner: repo.owner.login,
+      repo: repo.name,
+      branch: repo.default_branch
+    })
+
+    const lastCommit = mainBranch.data.commit
+    const lastCommitDate = lastCommit?.commit?.committer?.date
+    if (lastCommitDate == null) {
+      log.info('Skipping (no commit found on default branch)')
+      return
+    }
+
+    const commitYear = parseInt(lastCommitDate.slice(0, 4), 10)
+    if (licenseYears.end >= commitYear) {
+      log.info('Already up to date')
+      return
+    }
+
+    const newRange: LicenseYearRange = {
+      ...licenseYears,
+      end: commitYear
+    }
+
+    log.info(`Should update from ${licenseYears.start}-${licenseYears.end} to ${newRange.start}-${newRange.end}`)
+
+    const existing = await searchExistingPr(octokit, repo, BRANCH_NAME)
+    if (existing != null) {
+      log.info(`A PR already exists for branch ${BRANCH_NAME}, see ${existing.webUrl}`)
+      return
+    }
+
+    const pr = await createPrToUpdateFile(octokit, repo, {
+      fileBlobSha: license.sha,
+      path: LICENSE_PATH,
+      content: updateRange(license.content, newRange)
+    }, {
+      branch: BRANCH_NAME,
+      parentCommitSha: lastCommit.sha,
+      subject: 'chore(license): Update copyright range',
+      comment: `It looks like the most recent commit is dated to the year ${commitYear}. This PR updates the copyright range in LICENSE to match that.`
+    })
+
+    log.info(`PR created, see ${pr.webUrl}`)
   }
-
-  const licenseYears = extractRange(license.content)
-  if (licenseYears == null) {
-    log.info('Skipping (unable to extract a date range from the license file)')
-    return
-  }
-
-  const mainBranch = await octokit.rest.repos.getBranch({
-    owner: repo.owner.login,
-    repo: repo.name,
-    branch: repo.default_branch
-  })
-
-  const lastCommit = mainBranch.data.commit
-  const lastCommitDate = lastCommit?.commit?.committer?.date
-  if (lastCommitDate == null) {
-    log.info('Skipping (no commit found on default branch)')
-    return
-  }
-
-  const commitYear = parseInt(lastCommitDate.slice(0, 4), 10)
-  if (licenseYears.end >= commitYear) {
-    log.info('Already up to date')
-    return
-  }
-
-  const newRange: LicenseYearRange = {
-    ...licenseYears,
-    end: commitYear
-  }
-
-  log.info(`Should update from ${licenseYears.start}-${licenseYears.end} to ${newRange.start}-${newRange.end}`)
-
-  const existing = await searchExistingPr(octokit, repo, BRANCH_NAME)
-  if (existing != null) {
-    log.info(`A PR already exists for branch ${BRANCH_NAME}, see ${existing.webUrl}`)
-    return
-  }
-
-  const pr = await createPrToUpdateFile(octokit, repo, {
-    fileBlobSha: license.sha,
-    path: LICENSE_PATH,
-    content: updateRange(license.content, newRange)
-  }, {
-    branch: BRANCH_NAME,
-    parentCommitSha: lastCommit.sha,
-    subject: 'chore(license): Update copyright range',
-    comment: `It looks like the most recent commit is dated to the year ${commitYear}. This PR updates the copyright range in LICENSE to match that.`
-  })
-
-  log.info(`PR created, see ${pr.webUrl}`)
 }
 
 function extractRange (licenseText: string): LicenseYearRange | undefined {

--- a/automations/reconfigure.ts
+++ b/automations/reconfigure.ts
@@ -1,28 +1,27 @@
-import { Log } from '../lib/log.js'
-import { GraaOctokit, RepoOfAuthenticatedUser } from '../lib/types.js'
-import { boolean, defaulted, object } from 'superstruct'
-import { assertAutomationOptions } from '../lib/validation.js'
+import { Automation } from '../lib/automation.js'
+import { boolean, defaulted, Infer, object } from 'superstruct'
 
 const Options = object({
   'delete-branch-on-merge': defaulted(boolean(), false)
 })
 
 /**
- * Run a job for reconfiguring a subset of the repository settings.
- *
- * @param log The scoped logger.
- * @param octokit The API instance.
- * @param repo The repo to run this action on.
- * @param options The automation options.
+ * An automation for reconfiguring a subset of the repository settings.
  */
-export async function reconfigure (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: object): Promise<void> {
-  const opt = assertAutomationOptions(repo, Options, options)
+export const reconfigure: Automation<Infer<typeof Options>> = {
+  optionsStruct: Options,
 
-  await octokit.rest.repos.update({
-    owner: repo.owner.login,
-    repo: repo.name,
+  combineOptions (base, extend) {
+    return { ...base, ...extend }
+  },
 
-    // sample setting
-    delete_branch_on_merge: opt['delete-branch-on-merge']
-  })
+  async run (log, octokit, repo, options) {
+    await octokit.rest.repos.update({
+      owner: repo.owner.login,
+      repo: repo.name,
+
+      // sample setting
+      delete_branch_on_merge: options['delete-branch-on-merge']
+    })
+  }
 }

--- a/lib/automation.ts
+++ b/lib/automation.ts
@@ -1,0 +1,45 @@
+import { GraaOctokit, RepoOfAuthenticatedUser } from './types.js'
+import { licenseDate } from '../automations/license-date.js'
+import { reconfigure } from '../automations/reconfigure.js'
+import { files } from '../automations/files.js'
+import { Struct } from 'superstruct'
+import { Log } from './log.js'
+
+export interface Automation<Opt> {
+  /**
+   * The struct for validation of options objects.
+   */
+  optionsStruct: Struct<Opt>
+
+  /**
+   * A reducer to combine options from a base config with options from an extending config.
+   *
+   * The simplest case would be to return just the extend object here, to completely ignore and options from further up
+   * the config hierarchy. Other strategies such as merging keys or custom behavior are possible as well.
+   *
+   * @param base The options object found in the base config.
+   * @param extend The options object found in the extending config.
+   * @returns The resulting combined options.
+   */
+  combineOptions: (base: Opt, extend: Opt) => Opt
+
+  /**
+   * Execute this automation.
+   *
+   * @param log The logger.
+   * @param octokit The API client.
+   * @param repo The repo for which to run the automation.
+   * @param options The fully resolved and validated options.
+   */
+  run: (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: Opt) => Promise<void>
+}
+
+const AUTOMATIONS: ReadonlyMap<string, Automation<any>> = new Map<string, Automation<any>>([
+  ['license-date', licenseDate],
+  ['reconfigure', reconfigure],
+  ['files', files]
+])
+
+export function getAutomation (id: string): Automation<any> | undefined {
+  return AUTOMATIONS.get(id)
+}


### PR DESCRIPTION
This patch adds fully custom merging capabilities for automation option
objects. Previously, when an automation was specified with some set of
options A in a parent config (such as 'config:base'), and then again
with some set of options B in a child config (such as 'config:js-lib'),
only option set B would take effect. Now, each automation can specify
a reducer for merging its options to obtain a combined option set AB
which will be passed during automation execution. This is useful, for
example, for the 'files' automation. Specifying a file path twice will
override it, just as before, but specifying additional paths will not
replace the entire set of paths, but instead add to it, so that all
files, no matter where they are specified, will be processed.