### PR TITLE
fix(reconfigure): Perform update only when needed (closes #24)

### DIFF
--- a/src/automations/reconfigure.ts
+++ b/src/automations/reconfigure.ts
@@ -16,11 +16,17 @@ export const reconfigure: Automation<Infer<typeof Options>> = {
   },
 
   async run (log, octokit, repo, options) {
+    if (repo.delete_branch_on_merge === options['delete-branch-on-merge']) {
+      log.info('Already in expected state')
+      return
+    }
+
+    log.info('Updating settings')
+
     await octokit.rest.repos.update({
       owner: repo.owner.login,
       repo: repo.name,
 
-      // sample setting
       delete_branch_on_merge: options['delete-branch-on-merge']
     })
   }


### PR DESCRIPTION
This adds a check to see if any setting actually needs to change. If so,
the request is sent as before. If not, no request is sent. This has two
benefits: It saves API quota, and it stops spamming the account security
log.