### PR TITLE
fix: Fetch repo again after listing to have all props (closes #24)

### DIFF
--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1,4 +1,4 @@
-import { GraaOctokit, RepoOfAuthenticatedUser } from './github/types.js'
+import { GraaOctokit, RepoDetail } from './github/types.js'
 import { licenseDate } from './automations/license-date.js'
 import { reconfigure } from './automations/reconfigure.js'
 import { files } from './automations/files.js'
@@ -31,7 +31,7 @@ export interface Automation<Opt> {
    * @param repo The repo for which to run the automation.
    * @param options The fully resolved and validated options.
    */
-  run: (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, options: Opt) => Promise<void>
+  run: (log: Log, octokit: GraaOctokit, repo: RepoDetail, options: Opt) => Promise<void>
 }
 
 const AUTOMATIONS: ReadonlyMap<string, Automation<any>> = new Map<string, Automation<any>>([

--- a/src/automations/files.ts
+++ b/src/automations/files.ts
@@ -1,6 +1,6 @@
 import { Automation } from '../automation.js'
 import { Log } from '../log.js'
-import { GraaOctokit, RepoOfAuthenticatedUser } from '../github/types.js'
+import { GraaOctokit, RepoDetail } from '../github/types.js'
 import { Infer, record, string } from 'superstruct'
 import { tryReadFileAsUtf8 } from '../github/content.js'
 import { createPrToUpdateFile, searchExistingPr } from '../pr.js'
@@ -16,7 +16,7 @@ function pathToBranchName (path: string): string {
   return `chore/update-${normalized}`
 }
 
-async function handleFile (log: Log, octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, path: string, expectedContent: string): Promise<void> {
+async function handleFile (log: Log, octokit: GraaOctokit, repo: RepoDetail, path: string, expectedContent: string): Promise<void> {
   const mainBranch = await octokit.rest.repos.getBranch({
     owner: repo.owner.login,
     repo: repo.name,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { RepoOfAuthenticatedUser } from './github/types.js'
+import { RepoDetail, RepoOfAuthenticatedUser } from './github/types.js'
 
 export class AuthError extends Error {
   constructor (message: string) {
@@ -10,14 +10,14 @@ export class AuthError extends Error {
 export abstract class RepoError extends Error {
   readonly repo: string
 
-  protected constructor (repo: RepoOfAuthenticatedUser, message: string) {
+  protected constructor (repo: RepoOfAuthenticatedUser | RepoDetail, message: string) {
     super(message)
     this.repo = repo.full_name
   }
 }
 
 export class RepoConfigError extends RepoError {
-  constructor (repo: RepoOfAuthenticatedUser, message: string) {
+  constructor (repo: RepoOfAuthenticatedUser | RepoDetail, message: string) {
     super(repo, message)
     this.name = RepoConfigError.name
   }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -10,4 +10,5 @@ export type GraaOctokit = InstanceType<typeof Octokit & Constructor<Api> & Const
 type RestMethods = GraaOctokit['rest']
 
 export type RepoOfAuthenticatedUser = GetResponseDataTypeFromEndpointMethod<RestMethods['repos']['listForAuthenticatedUser']>[number]
+export type RepoDetail = GetResponseDataTypeFromEndpointMethod<RestMethods['repos']['get']>
 export type BranchOfRepo = GetResponseDataTypeFromEndpointMethod<RestMethods['repos']['getBranch']>

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,4 +1,4 @@
-import { GraaOctokit, RepoOfAuthenticatedUser } from './github/types.js'
+import { GraaOctokit, RepoDetail } from './github/types.js'
 
 export interface FileChange {
   fileBlobSha?: string
@@ -17,7 +17,7 @@ export interface PullRequestResult {
   webUrl: string
 }
 
-export async function searchExistingPr (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, branch: string): Promise<PullRequestResult | undefined> {
+export async function searchExistingPr (octokit: GraaOctokit, repo: RepoDetail, branch: string): Promise<PullRequestResult | undefined> {
   const options = {
     q: `repo:${repo.full_name} is:pr is:open head:${branch}`
   } as const
@@ -35,7 +35,7 @@ export async function searchExistingPr (octokit: GraaOctokit, repo: RepoOfAuthen
   return undefined
 }
 
-export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoOfAuthenticatedUser, change: FileChange, meta: PullRequestMetadata): Promise<PullRequestResult> {
+export async function createPrToUpdateFile (octokit: GraaOctokit, repo: RepoDetail, change: FileChange, meta: PullRequestMetadata): Promise<PullRequestResult> {
   await octokit.rest.git.createRef({
     owner: repo.owner.login,
     repo: repo.name,


### PR DESCRIPTION
The repo listing for the current user is missing some properties. By
fetching each active repo again separately, we can obtain a complete
representation.