### PR TITLE
chore: Remove rimraf dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@meyfa/eslint-config": "3.0.0",
         "@types/node": "18.14.2",
         "eslint": "8.34.0",
-        "rimraf": "4.1.2",
         "typescript": "4.9.5"
       }
     },
@@ -2547,21 +2546,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
-      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
-      "dev": true,
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4754,12 +4738,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
-      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
       "dev": true
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\"",
     "build": "npm run clean && tsc",
     "start": "node dist/index.js",
     "lint": "tsc --noEmit && eslint --ignore-path .gitignore .",
@@ -20,7 +20,6 @@
     "@meyfa/eslint-config": "3.0.0",
     "@types/node": "18.14.2",
     "eslint": "8.34.0",
-    "rimraf": "4.1.2",
     "typescript": "4.9.5"
   },
   "dependencies": {


### PR DESCRIPTION
Since we depend on Node.js anyway, we can use its CLI to remove the dist directory, without having to depend on a 3rd-party package.