### PR TITLE
feat: Group devDependencies into one pull request

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,17 @@
       "extends": ["schedule:weekly"]
     },
     {
-      "matchPackagePatterns": [
-        "^@octokit/"
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": [
+        "^@types/",
+        "-types$"
       ],
+      "groupName": "dev dependencies (non-major)",
+      "groupSlug": "dev-dependencies-non-major"
+    },
+    {
+      "matchPackagePatterns": ["^@octokit/"],
       "groupName": "octokit packages"
     }
   ],

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -3,6 +3,20 @@ import { indent } from '../util/indent.js'
 
 export const commonRenovatePackageRules = `{
   "matchDepTypes": ["devDependencies"],
+  "extends": ["schedule:weekly"]
+},
+{
+  "matchDepTypes": ["devDependencies"],
+  "matchUpdateTypes": ["minor", "patch"],
+  "excludePackagePatterns": [
+    "^@types/",
+    "-types$"
+  ],
+  "groupName": "dev dependencies (non-major)",
+  "groupSlug": "dev-dependencies-non-major"
+},
+{
+  "matchDepTypes": ["devDependencies"],
   "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
   "matchPackageNames": [
     "typescript",
@@ -22,14 +36,10 @@ export const commonRenovatePackageRules = `{
 
 const renovateJson = `{
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": ["dependencies"],
   "packageRules": [
-    {
-      "matchDepTypes": ["devDependencies"],
-      "extends": ["schedule:weekly"]
-    },
     ${indent(commonRenovatePackageRules, '    ')}
   ]
 }

--- a/src/configs/js-app.ts
+++ b/src/configs/js-app.ts
@@ -8,10 +8,6 @@ const renovateJson = `{
   ],
   "labels": ["dependencies"],
   "packageRules": [
-    {
-      "matchDepTypes": ["devDependencies"],
-      "extends": ["schedule:weekly"]
-    },
     ${indent(commonRenovatePackageRules, '    ')}
   ],
   "lockFileMaintenance": {

--- a/src/configs/js-lib.ts
+++ b/src/configs/js-lib.ts
@@ -8,10 +8,6 @@ const renovateJson = `{
   ],
   "labels": ["dependencies"],
   "packageRules": [
-    {
-      "matchDepTypes": ["devDependencies"],
-      "extends": ["schedule:weekly"]
-    },
     ${indent(commonRenovatePackageRules, '    ')}
   ]
 }


### PR DESCRIPTION
Type definition updates are excluded for now.

As a drive-by, change Renovate's `config:base` to `config:recommended` since `config:base` has been renamed (unchanged) and is deprecated.