### PR TITLE
chore(license): Update copyright range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 - 2024 Fabian Meyer
+Copyright (c) 2022 - 2025 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Note: This PR was created automatically by [GRAA](https://github.com/meyfa/graa).

It looks like the most recent commit is dated to the year 2025. This PR updates the copyright range in LICENSE to match that.