### PR TITLE
feat(configs): Update dev deps monthly with reduced automerge

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -3,7 +3,7 @@ import { indent } from '../util/indent.js'
 
 export const commonRenovatePackageRules = `{
   "matchDepTypes": ["devDependencies"],
-  "extends": ["schedule:weekly"]
+  "extends": ["schedule:monthly"]
 },
 {
   "matchDepTypes": ["devDependencies"],
@@ -12,27 +12,9 @@ export const commonRenovatePackageRules = `{
   "groupSlug": "dev-dependencies-non-major"
 },
 {
-  "matchDepTypes": ["devDependencies"],
-  "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
-  "matchPackageNames": [
-    "typescript",
-    "eslint",
-    "mocha",
-    "chai",
-    "stylelint",
-    "stylelint-config-standard",
-    "@meyfa/eslint-config"
-  ],
-  "automerge": true
-},
-{
   "matchManagers": ["github-actions"],
   "matchDepTypes": ["action"],
   "groupName": "actions"
-},
-{
-  "matchPackageNames": ["/^@octokit//"],
-  "groupName": "octokit packages"
 }`
 
 const renovateJson = `{

--- a/src/configs/js-app.ts
+++ b/src/configs/js-app.ts
@@ -12,6 +12,7 @@ const renovateJson = `{
   ],
   "lockFileMaintenance": {
     "enabled": true,
+    "extends": ["schedule:monthly"],
     "automerge": true
   }
 }


### PR DESCRIPTION
This patch includes the following changes to the Renovate configuration:

1. Development dependencies and lockfile maintenance updates will run monthly instead of weekly to reduce noise.
2. Automerging of minor and patch updates is disabled for improved security and stability.
3. The octokit exception is removed as it concerns specifically only this repository, and also, should already be covered by the grouping rules.